### PR TITLE
Tidy use statements and type hinting

### DIFF
--- a/src/Dynmark.php
+++ b/src/Dynmark.php
@@ -1,11 +1,7 @@
 <?php namespace Dynmark;
 
-use Dynmark\Commands\Sms\Send;
 use Dynmark\Commands\Command;
-
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Message\Response;
 
 class Dynmark {
 

--- a/src/Dynmark.php
+++ b/src/Dynmark.php
@@ -60,10 +60,10 @@ class Dynmark {
     /**
      * Set the Client
      *
-     * @param ClientInterface $client
+     * @param Client $client
      * @return $this
      */
-    public function setClient(ClientInterface $client)
+    public function setClient(Client $client)
     {
         $this->client = $client;
         return $this;

--- a/tests/Dynmark/SomethingTest.php
+++ b/tests/Dynmark/SomethingTest.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: hughdowner
+ * Date: 07/05/2015
+ * Time: 09:18
+ */


### PR DESCRIPTION
- Removed two unused use statements from the top of the file
- Change ClientInterface type hint to Client
